### PR TITLE
RS-2 Refactor code to make it easier to unit test and maintain + env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     ports:
       - "3000:3000"
     command: npm run dev # Override CMD ["npm", "start"]
+    env_file: .env
+    environment:
+      - RUN_SCRAPER=${RUN_SCRAPER:-false} # Use RUN_SCRAPER if it exists otherwise use false
   redis:
     image: redis:8
     ports:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,89 +1,14 @@
-import Fastify from 'fastify'
-import { getHTML, getArticleHrefs, getUrls } from './lib/scrape.ts'
-import { htmlToMarkdown } from './lib/markdown.ts'
-import { store, get } from './model/cache.ts'
-// import { getPool } from './db.ts'
-import fs from 'fs';
-import path from 'path'
+import { start } from './server.ts'
+import { scrape } from './lib/scrape.ts'
 
-const fastify = Fastify({
-  logger: true
-})
-
-const rootPath = process.cwd()
-const filePath = path.join(rootPath, "documents")
-
-const DELAY = 5000
-const DELAY_LONG = 300000 // 5 min
-
-//minWait is in seconds
-const DELAY_VARIABILITY = (minWait: number) => {
-  return (Math.floor(Math.random() * 10) * 1000 * minWait)
-}
-
-fastify.get('/', async (req, res) => {
-  
-  const archiveUrls = getUrls()
-  const cachedUrl = await get('archive_url')
-  const index = archiveUrls.findIndex((url) => url === cachedUrl)
-  const reducedUrls = index > -1 ? archiveUrls.slice(index) : archiveUrls
-  
-  for (let url of reducedUrls) {
-    await store('archive_url', url)
-    const archiveHTML = await getHTMLWrapper<string>(getHTML, [url])
-    const links = await getArticleHrefs(archiveHTML)
-
-    if (!links) continue
-
-    for (const link of links) {
-      const match = link.match(/m=news\/([^?]+)/) ?? []
-      const fileName = `${match[1]?.replaceAll('-', '_')}.html`
-      try {
-        fs.readFileSync(path.join(filePath, fileName))
-      } catch (error) {
-        const devdiaryHTML = await getHTMLWrapper<string>(getHTML, [link])
-        console.log('[INFO] Wrote ', fileName)
-        fs.writeFileSync(path.join(filePath, fileName), devdiaryHTML, "utf8")
-        await sleep(DELAY)
-      }
-      continue
-    }
-  }
-})
-
-const getHTMLWrapper = async <T>(fn: Function, args: string[], retries: number = 5): Promise<T> => {
-  for (let i = 1; i < retries; i++) {
-    try {
-      return await fn(...args)
-    }
-    catch (err) {
-      console.log('[ERROR] Putting to sleep for ' + (DELAY_LONG * i) / 1000)
-      await sleep(DELAY_LONG * i)
-    }
-  }
-  throw new Error(`[FATAL] All retries failed for url ${args}`)
-}
-
-const sleep = async (delay: number) => {
-  await new Promise(res => setTimeout(res, delay + DELAY_VARIABILITY(5)))
-}
-
-const start = async () => {
-  try {
-    await fastify.listen({ port: 3000, host: '0.0.0.0' })
-    console.log('[INFO] Server running on http://localhost:3000')
-  } catch (err) {
-    fastify.log.error(err)
-    process.exit(1)
+async function main() {
+  if (process.env.RUN_SCRAPER === 'true') {
+    console.log('[INFO] Scraping data')
+    await scrape()
+  } else {
+    console.log('[INFO] Running server')
+    await start()
   }
 }
 
-start()
-
-// Commented out since not doing storage yet
-// const storeInDatabase = async () => {
-//   const [rows] = await pool.query(
-//    'INSERT INTO pages (url, html) VALUES (?, ?)',
-//     [URL, rawHTML]);
-//   console.log(rows);
-// }
+main()

--- a/src/model/cache.ts
+++ b/src/model/cache.ts
@@ -13,7 +13,7 @@ export const store = async (key: string, value: string | number): Promise<void> 
     throw new Error('[FATAL] Redis failed to store a value')
   }
 
-  console.log(`[INFO] Value stored: ${reply}`)
+  console.log(`[CACHE] Value stored: ${reply}`)
 }
 
 export const get = async (key: string): Promise<string | null> => {

--- a/src/model/cache.ts
+++ b/src/model/cache.ts
@@ -7,13 +7,13 @@ const client = redis.createClient({
 export const store = async (key: string, value: string | number): Promise<void> => {
   await client.set(key, value)
 
-  const replay = await client.get(key);
+  const reply = await client.get(key);
 
-  if (!replay) {
+  if (!reply) {
     throw new Error('[FATAL] Redis failed to store a value')
   }
 
-  console.log(`[INFO] Value stored: ${replay}`)
+  console.log(`[INFO] Value stored: ${reply}`)
 }
 
 export const get = async (key: string): Promise<string | null> => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,19 @@
+import Fastify from 'fastify'
+
+const fastify = Fastify({
+  logger: true
+})
+
+fastify.get('/', async (req, res) => {
+  res.send({ status: 'TEMP' })
+})
+
+export const start = async () => {
+  try {
+    await fastify.listen({ port: 3000, host: '0.0.0.0' })
+    console.log('[INFO] Server running on http://localhost:3000')
+  } catch (err) {
+    fastify.log.error(err)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
- Refactor code to make it easier to unit test and maintain
- Adds env vars to control when to scrape, instead of having to rely in fastify curl